### PR TITLE
Add support in peerDependencies of react and react-dom to version ^18…

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "@storybook/components": "^6.4.0",
     "@storybook/core-events": "^6.4.0",
     "@storybook/theming": "^6.4.0",
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "react": {


### PR DESCRIPTION
Add support in peerDependencies of react and react-dom to version ^18.0.0
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.1-canary.3.42f9ede.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-version@0.1.1-canary.3.42f9ede.0
  # or 
  yarn add storybook-version@0.1.1-canary.3.42f9ede.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
